### PR TITLE
feat: add sleep detection dashboard

### DIFF
--- a/web/dashboards/sleep/index.html
+++ b/web/dashboards/sleep/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sleep Detection</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <style>
+      .row { display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+      .status { font-weight:bold; font-size:1.2rem; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Sleep Detection</h1>
+      <p class="muted">Band power を使って睡眠状態を判定します。</p>
+    </header>
+    <main>
+      <section class="row">
+        <button id="start">Start</button>
+        <button id="stop">Stop</button>
+        <span id="wsstatus" class="muted">WS: connecting…</span>
+      </section>
+      <section>
+        <h3>Current State</h3>
+        <div id="state" class="status">-</div>
+        <div id="ratio" class="muted"></div>
+      </section>
+    </main>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/web/dashboards/sleep/index.js
+++ b/web/dashboards/sleep/index.js
@@ -1,0 +1,71 @@
+import { wsConnect, api } from '/lib/dashboard-sdk.js';
+
+const $ = (id) => document.getElementById(id);
+const startBtn = $('start');
+const stopBtn = $('stop');
+const wsStatus = $('wsstatus');
+const stateEl = $('state');
+const ratioEl = $('ratio');
+
+let powLabels = [];
+
+function calcState(pow) {
+  const bandSums = { theta:0, alpha:0, betaL:0, betaH:0, gamma:0 };
+  const counts = { theta:0, alpha:0, betaL:0, betaH:0, gamma:0 };
+  powLabels.forEach((lab, i) => {
+    const v = pow[i] || 0;
+    const parts = lab.split('/');
+    if (parts.length === 2) {
+      const band = parts[1];
+      if (bandSums[band] !== undefined) {
+        bandSums[band] += v;
+        counts[band]++;
+      }
+    }
+  });
+  const avg = (band, def=0) => counts[band] ? bandSums[band]/counts[band] : def;
+  const theta = avg('theta');
+  const alpha = avg('alpha');
+  const beta = (avg('betaL') + avg('betaH')) / 2;
+  const ratio = theta / (alpha + beta + 1e-6);
+  let state = 'Awake';
+  if (ratio > 1.5) state = 'Sleep';
+  else if (ratio > 1.0) state = 'Drowsy';
+  return { ratio, state };
+}
+
+const ws = wsConnect({
+  onOpen: () => { wsStatus.textContent = 'WS: connected'; },
+  onClose: () => { wsStatus.textContent = 'WS: disconnected (retrying)'; },
+  onError: () => { wsStatus.textContent = 'WS: error'; },
+  onType: {
+    labels: (p) => {
+      if (p.streamName === 'pow' && Array.isArray(p.labels)) {
+        powLabels = p.labels;
+      }
+    },
+    pow: (payload) => {
+      const arr = payload.pow || [];
+      if (!arr.length || !powLabels.length) return;
+      const { ratio, state } = calcState(arr);
+      stateEl.textContent = state;
+      ratioEl.textContent = `theta/(alpha+beta): ${ratio.toFixed(2)}`;
+    }
+  }
+});
+
+startBtn.addEventListener('click', async () => {
+  try {
+    await api.stream.start('pow');
+  } catch (e) {
+    alert('start error: ' + e.message);
+  }
+});
+
+stopBtn.addEventListener('click', async () => {
+  try {
+    await api.stream.stop('pow');
+  } catch (e) {
+    alert('stop error: ' + e.message);
+  }
+});

--- a/web/dashboards/sleep/manifest.json
+++ b/web/dashboards/sleep/manifest.json
@@ -1,0 +1,5 @@
+{
+  "title": "Sleep Detection",
+  "description": "Detects sleepiness from band power ratios",
+  "tags": ["pow", "sleep"]
+}


### PR DESCRIPTION
## Summary
- add sleep detection dashboard computing theta/(alpha+beta) ratio
- expose as dashboard via manifest

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4db2dbcac832f8217074c4dc1c8b6